### PR TITLE
Fix widget factory call in CLI runner

### DIFF
--- a/rnascope_counter/__main__.py
+++ b/rnascope_counter/__main__.py
@@ -21,7 +21,9 @@ def main(argv: list[str] | None = None) -> None:
     if args.thalamus:
         viewer.open(str(args.thalamus), channel_axis=0, name="thalamus")
 
-    viewer.window.add_dock_widget(counter_widget(viewer), name="RNAScope Counter", area="right")
+    viewer.window.add_dock_widget(
+        counter_widget(viewer=viewer), name="RNAScope Counter", area="right"
+    )
     napari.run()
 
 


### PR DESCRIPTION
## Summary
- pass `viewer` as a keyword when creating the RNAScope counter widget

## Testing
- `python -m py_compile rnascope_counter/__main__.py`
- `pytest -q`
- `python -m rnascope_counter --help`
- `pip install napari[all]` *(fails: Could not find a version that satisfies the requirement napari[all])*

------
https://chatgpt.com/codex/tasks/task_e_689a1a9325d48326a10721c0ee130a4a