### PR TITLE
Fix viewer binding in counter widget

### DIFF
--- a/rnascope_counter/__main__.py
+++ b/rnascope_counter/__main__.py
@@ -22,7 +22,9 @@ def main(argv: list[str] | None = None) -> None:
         viewer.open(str(args.thalamus), channel_axis=0, name="thalamus")
 
     viewer.window.add_dock_widget(
-        counter_widget(viewer=viewer), name="RNAScope Counter", area="right"
+        counter_widget(viewer={"value": viewer, "visible": False}),
+        name="RNAScope Counter",
+        area="right",
     )
     napari.run()
 


### PR DESCRIPTION
## Summary
- avoid TypeError when constructing the widget by binding the napari viewer using magicgui's options dict

## Testing
- `pytest -q`
- `python -m rnascope_counter --help`


------
https://chatgpt.com/codex/tasks/task_e_689a1bd9f80083268a6cd906712e4f3c