### PR TITLE
Consolidate ROI layers for hippocampus and thalamus

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ The three channels should be:
 - GOB, 560 nm, Opal 570
 - GOA, 650 nm, Opal 650
 
-Takes in the paths to 2 montage images (hippocampus and thalamus) and allows the user to select ROIs. The first image displayed is of the hippocampus and allows the user to define 3 ROIs:
+Takes in the paths to 2 montage images (hippocampus and thalamus) and allows the user to select ROIs. The application creates two empty shapes layers named ``hippo_rois`` and ``thalamus_rois``. The first image displayed is of the hippocampus and ``hippo_rois`` should contain 3 polygons drawn in this order:
 - CA1
 - CA3
 - DG
-Second montage is of the thalamus and the user defines one region (Thalamus).
+The second montage is of the thalamus and ``thalamus_rois`` should contain one polygon representing the thalamus.
 
 Then provides analysis of each region defined, including:
 - Number of spots in GOA/GOB channel
@@ -30,4 +30,4 @@ python -m rnascope_counter --hippocampus path/to/hippo.tif --thalamus path/to/th
 ```
 
 After launching, use the docked *RNAScope Counter* widget to enter the pixel spacing (default `0.4475` µm/pixel), choose the output CSV location, and adjust the `threshold` and `min_distance` parameters that control spot detection.
-Draw polygon ROIs on each image before pressing **Analyze**.
+Draw polygon ROIs on each image before pressing **Analyze**. In ``hippo_rois`` add three polygons in the order CA1, CA3, DG; ``thalamus_rois`` should contain one polygon for the thalamus.

--- a/rnascope_counter/__main__.py
+++ b/rnascope_counter/__main__.py
@@ -42,13 +42,21 @@ def main(argv: "list[str]" | None = None) -> None:
         load_image(args.thalamus, "thalamus")
 
     # Auto-create ROI layers
-    for roi_name in ["CA1_rois", "CA3_rois", "DG_rois", "Thalamus_rois"]:
-        viewer.add_shapes(
-            name=roi_name,
-            shape_type="polygon",
-            edge_color="yellow",
-            face_color="transparent",
-        )
+    # ``hippo_rois`` is expected to contain three polygons corresponding to
+    # hippocampal regions CA1, CA3, and DG in that order. ``thalamus_rois``
+    # should contain a single polygon covering the thalamus.
+    viewer.add_shapes(
+        name="hippo_rois",
+        shape_type="polygon",
+        edge_color="yellow",
+        face_color="transparent",
+    )
+    viewer.add_shapes(
+        name="thalamus_rois",
+        shape_type="polygon",
+        edge_color="yellow",
+        face_color="transparent",
+    )
 
     # Add dock widget
     viewer.window.add_dock_widget(

--- a/rnascope_counter/widget.py
+++ b/rnascope_counter/widget.py
@@ -37,7 +37,10 @@ def counter_widget(
     hippo, thalamus : napari.layers.Image
         Three-channel images with Nuclei, GOB, GOA channels.
     hippo_rois, thalamus_rois : napari.layers.Shapes
-        Polygon ROIs drawn on the corresponding images.
+        Polygon ROIs drawn on the corresponding images. ``hippo_rois`` should
+        contain three polygons representing CA1, CA3, and DG in that order;
+        ``thalamus_rois`` should contain a single polygon representing the
+        thalamus.
     output : pathlib.Path
         Location where results will be written as CSV.
     pixel_spacing : float
@@ -86,6 +89,7 @@ def counter_widget(
 
     # Hippocampus regions CA1, CA3, DG
     hippo_names = ["CA1", "CA3", "DG"]
+    # ``hippo_rois`` is expected to contain three polygons in this order.
     _analyze(hippo.data, hippo_rois.data, hippo_names)
 
     # Thalamus region


### PR DESCRIPTION
## Summary
- create unified `hippo_rois` and `thalamus_rois` shapes layers
- document ROI layer names and polygon ordering
- clarify expected ROI structure in widget and README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689af1e38cec83268f5f1a2e9323e20b