### PR TITLE
feat: save analysis artifacts

### DIFF
--- a/rnascope_counter/widget.py
+++ b/rnascope_counter/widget.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List
 import pathlib
+import json
 
 import numpy as np
 import pandas as pd
 from magicgui import magic_factory
+from skimage import io
 from skimage.draw import polygon2mask
 from skimage.feature import peak_local_max
 
@@ -16,6 +18,7 @@ from skimage.feature import peak_local_max
     pixel_spacing={"min": 0.0, "value": 0.4475},
     threshold={"min": 0.0, "value": 100.0},
     min_distance={"min": 1, "value": 5},
+    output_dir={"mode": "d"},
 )
 def counter_widget(
     viewer: "napari.viewer.Viewer",
@@ -23,12 +26,12 @@ def counter_widget(
     hippo_rois: "napari.layers.Shapes",
     thalamus: "napari.layers.Image",
     thalamus_rois: "napari.layers.Shapes",
-    output: "pathlib.Path" = Path("results.csv"),
+    output_dir: "pathlib.Path" = Path("results"),
     pixel_spacing: float = 0.4475,
     threshold: float = 100.0,
     min_distance: int = 5,
 ) -> "pandas.DataFrame":
-    """Analyze ROIs and write results to ``output``.
+    """Analyze ROIs and write results to ``output_dir``.
 
     Parameters
     ----------
@@ -41,8 +44,8 @@ def counter_widget(
         contain three polygons representing CA1, CA3, and DG in that order;
         ``thalamus_rois`` should contain a single polygon representing the
         thalamus.
-    output : pathlib.Path
-        Location where results will be written as CSV.
+    output_dir : pathlib.Path
+        Directory where results and associated files will be written.
     pixel_spacing : float
         Microns per pixel.
     threshold : float
@@ -51,20 +54,50 @@ def counter_widget(
         Minimum distance between peaks.
     """
 
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    params = {
+        "pixel_spacing": pixel_spacing,
+        "threshold": threshold,
+        "min_distance": min_distance,
+    }
+    with (output_dir / "params.json").open("w") as f:
+        json.dump(params, f, indent=2)
+
     results: List[dict] = []
 
     def _analyze(img_data, rois_data, region_names):
         for verts, region_name in zip(rois_data, region_names):
+            np.save(output_dir / f"{region_name}_roi.npy", verts)
             mask = polygon2mask(img_data.shape[1:], verts)
             area_um2 = float(mask.sum()) * pixel_spacing ** 2
+            ys, xs = np.where(mask)
+            minr, maxr = ys.min(), ys.max() + 1
+            minc, maxc = xs.min(), xs.max() + 1
             for ch_idx, ch_name in enumerate(["GOB", "GOA"], start=1):
-                channel_img = img_data[ch_idx, :, :]  # 2D slice
+                channel_img = img_data[ch_idx, :, :]
                 coords = peak_local_max(
                     channel_img,
                     threshold_abs=threshold,
                     min_distance=min_distance,
                     labels=mask,
                 )
+
+                channel_masked = np.where(mask, channel_img, 0)
+                cutout = channel_masked[minr:maxr, minc:maxc]
+                io.imsave(output_dir / f"{region_name}_{ch_name}.png", cutout)
+
+                annotated = cutout.copy()
+                for r, c in coords:
+                    r -= minr
+                    c -= minc
+                    rr_start, rr_end = max(r - 1, 0), min(r + 2, annotated.shape[0])
+                    cc_start, cc_end = max(c - 1, 0), min(c + 2, annotated.shape[1])
+                    annotated[rr_start:rr_end, c] = annotated.max()
+                    annotated[r, cc_start:cc_end] = annotated.max()
+                io.imsave(output_dir / f"{region_name}_{ch_name}_spots.png", annotated)
+
                 if coords.size:
                     viewer.add_points(
                         coords,
@@ -96,5 +129,5 @@ def counter_widget(
     _analyze(thalamus.data, thalamus_rois.data, ["Thalamus"])
 
     df = pd.DataFrame(results)
-    df.to_csv(output, index=False)
+    df.to_csv(output_dir / "results.csv", index=False)
     return df


### PR DESCRIPTION
## Summary
- allow users to choose an output directory
- write parameters, ROI coordinates, cutouts and annotated images for each region
- save analysis results to `results.csv` within the directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689af640e37c83268ff48fe8495b4856